### PR TITLE
Dependencies Refactor

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,7 +68,6 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core.ktx)
 
-    // TODO: maybe adding this as a separate module?
     api(libs.junit4)
     api(libs.androidx.test.core)
     api(libs.kotlinx.coroutines.test)

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -8,5 +8,5 @@ android {
 }
 
 dependencies {
-    implementation(libs.kotlinx.coroutines.android)
+    api(libs.kotlinx.coroutines.android)
 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
     implementation(project(":core:common"))
 
     implementation(libs.androidx.core.ktx)
-    implementation(libs.kotlinx.coroutines.android)
     implementation(libs.retrofit.core)
     implementation(libs.gson.core)
     implementation(libs.gson.converter)

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -8,9 +8,9 @@ android {
 }
 
 dependencies {
+    implementation(project(":core:common"))
     implementation(project(":core:data"))
 
-    implementation(libs.kotlinx.coroutines.android)
     implementation(libs.hilt.android)
     kapt(libs.hilt.compiler)
 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -13,8 +13,9 @@ android {
 dependencies {
     implementation(project(":core:common"))
     implementation(project(":core:data"))
-    implementation(libs.androidx.core.ktx)
 
+    api(libs.androidx.appcompat)
+    api(libs.androidx.core.ktx)
     api(libs.androidx.compose.foundation)
     api(libs.androidx.compose.foundation.layout)
     api(libs.androidx.compose.material.iconsExtended)
@@ -27,7 +28,6 @@ dependencies {
     api(libs.androidx.metrics)
     api(libs.androidx.tracing.ktx)
 
-    // TODO: maybe adding this as a separate module?
     api(libs.junit4)
     api(libs.androidx.test.core)
     api(libs.kotlinx.coroutines.test)

--- a/ui/detail/build.gradle.kts
+++ b/ui/detail/build.gradle.kts
@@ -17,17 +17,10 @@ dependencies {
     implementation(project(":core:ui"))
     implementation(project(":core:domain"))
 
-    implementation(libs.androidx.compose.material.iconsExtended)
-    implementation(libs.androidx.compose.material3)
-    implementation(libs.androidx.compose.material3.windowSizeClass)
-    implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.runtime.tracing)
-    implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.lifecycle.runtimeCompose)
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.accompanist.systemuicontroller)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.androidx.core.ktx)
 }

--- a/ui/home/build.gradle.kts
+++ b/ui/home/build.gradle.kts
@@ -15,17 +15,11 @@ dependencies {
     implementation(project(":core:domain"))
     implementation(project(":ui:detail"))
 
-    implementation(libs.androidx.compose.material.iconsExtended)
-    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material3.windowSizeClass)
-    implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.runtime.tracing)
-    implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.lifecycle.runtimeCompose)
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.accompanist.systemuicontroller)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.androidx.core.ktx)
 }

--- a/ui/search/build.gradle.kts
+++ b/ui/search/build.gradle.kts
@@ -18,17 +18,10 @@ dependencies {
     implementation(project(":core:ui"))
     implementation(project(":ui:detail"))
 
-    implementation(libs.androidx.compose.material.iconsExtended)
-    implementation(libs.androidx.compose.material3)
-    implementation(libs.androidx.compose.material3.windowSizeClass)
-    implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.runtime.tracing)
-    implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.lifecycle.runtimeCompose)
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.accompanist.systemuicontroller)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.androidx.core.ktx)
 }


### PR DESCRIPTION
I didn't notice that I'm using `api` for a few dependencies. With `api`, we don't have to define the same dependency twice.